### PR TITLE
fixed ideas being displayed to all users

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,7 +1,7 @@
 class IdeasController < ApplicationController
 
   def index
-    @ideas = Idea.all
+    @ideas = current_user.ideas
   end
 
   def new

--- a/spec/features/user_create_idea_spec.rb
+++ b/spec/features/user_create_idea_spec.rb
@@ -75,4 +75,30 @@ RSpec.describe Admin::CategoriesController, type: :feature do
 
   end
 
+  describe "a logged in user" do
+    it "cant see the ideas of another logged in user" do
+      user = User.find_by(username: "Lani")
+      category = Category.find_by(name: "Dogs I Like")
+      idea = Idea.create(name: "Golden Doodles",
+                         description: "They are fun and don't shed.",
+                         category_id: category.id,
+                         user_id: user.id)
+      visit user_ideas_path(user, idea)
+
+      within("#ideas") do
+        expect(page).to have_content("Golden Doodles")
+      end
+
+      click_on "Logout"
+      User.create(username: "Travis", password: "password")
+      visit login_path
+      fill_in "session[username]", with: "Travis"
+      fill_in "session[password]", with: "password"
+      click_button "Login"
+      within("#ideas") do
+        expect(page).not_to have_content("Golden Doodles")
+      end
+    end
+  end
+
 end

--- a/spec/features/user_create_idea_spec.rb
+++ b/spec/features/user_create_idea_spec.rb
@@ -100,5 +100,4 @@ RSpec.describe Admin::CategoriesController, type: :feature do
       end
     end
   end
-
 end


### PR DESCRIPTION
added test to confirm that one user cant see the ideas of another user. verified this personally as well by manually logging in on two different usernames and checking that the same ideas werent displayed
